### PR TITLE
fixed url filter for cross origin ajax requests

### DIFF
--- a/js/demo.js
+++ b/js/demo.js
@@ -111,7 +111,9 @@ var Demo = {
                 base = base.split('?')[0];
             }
 
-            options.url = base + options.url.substr(1);
+            if (options.url.indexOf('://') == -1) {
+				options.url = base + options.url.substr(1);
+			}
         });
     },
 


### PR DESCRIPTION
Apparently the url filter was only supposed to be used in same-origin requests . I know this is just a demo but still it would be nice to support cross origin requests since this is for mobile .
